### PR TITLE
add ntt reference code - cpp only

### DIFF
--- a/ntt/reference_code/arithmetic.cpp
+++ b/ntt/reference_code/arithmetic.cpp
@@ -1,0 +1,116 @@
+/*
+ * Copyright (C) 2022 DZK
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "arithmetic.hpp"
+
+using namespace std;
+
+// Add two Goldilocks elements together
+//
+// The number may not be between 0..MODULUS - 1,
+// it can be between MODULUS - 1..2^64-1.
+GF add(GF left, GF right) {
+	GF res = left + right;
+
+	bool overflow = res.get_bit(64);
+	res.set_bit(64, false);
+	if(overflow) {
+		res = res + EPSILON;
+	}
+
+	overflow = res.get_bit(64);
+	res.set_bit(64, false);
+	if(overflow) {
+		res = res + EPSILON;
+	}
+
+	return res;
+}
+
+// Subtract a Goldilocks element from another one
+//
+// The number may not be between 0..MODULUS - 1,
+// it can be between MODULUS - 1..2^64-1.
+GF sub(GF left, GF right) {
+	GF res = left - right;
+
+	bool underflow = res.get_bit(64);
+	res.set_bit(64, false);
+	if(underflow) {
+		res = res - EPSILON;
+	}
+
+	underflow = res.get_bit(64);
+	res.set_bit(64, false);
+	if(underflow) {
+		res = res - EPSILON;
+	}
+
+	return res;
+}
+
+// Negate a Goldilocks element
+GF negate(GF x) {
+	if(x.is_zero()){
+		return x;
+	} else {
+		return MODULUS - to_canonical(x);
+	}
+}
+
+// Multiply two Goldilocks elements
+GF mult(GF left, GF right) {
+	ap_ulong left_u64 = left.to_uint64();
+	ap_ulong right_u64 = right.to_uint64();
+
+	GF_MULT left_u128 = GF_MULT(left_u64);
+	GF_MULT right_u128 = GF_MULT(right_u64);
+
+	GF_MULT res = left_u128 * right_u128;
+
+	GF res_lo = GF((res & MASK).to_uint64());
+	GF res_hi = GF((res >> 64).to_uint64());
+
+	GF res_hi_hi = GF(res_hi >> 32);
+    GF res_hi_lo = GF(res_hi & EPSILON);
+
+    GF t0 = res_lo - res_hi_hi;
+    bool underflow = t0.get_bit(64);
+    t0.set_bit(64, false);
+    if(underflow) {
+    	t0 = t0 - EPSILON;
+    }
+
+    GF t1 = res_hi_lo * EPSILON;
+
+    GF final_res = t0 + t1;
+    bool overflow = final_res.get_bit(64);
+    final_res.set_bit(64, false);
+    if(overflow) {
+    	final_res = final_res + EPSILON;
+    }
+
+    return final_res;
+}
+
+//
+
+GF to_canonical(GF x) {
+	if(x >= MODULUS) {
+		return x - MODULUS;
+	}
+	return x;
+}

--- a/ntt/reference_code/arithmetic.hpp
+++ b/ntt/reference_code/arithmetic.hpp
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2022 DZK
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef _ARITHMETIC_FUNC_H_
+#define _ARITHMETIC_FUNC_H_
+
+#include <ap_int.h>
+
+typedef ap_uint<65> GF;
+const GF EPSILON = GF((1ull << 32) - 1);
+const GF ZERO = GF(0);
+const GF ONE = GF(1);
+const GF TWO = GF(2);
+const GF MODULUS = GF(0xFFFFFFFF00000001);
+
+typedef ap_uint<128> GF_MULT;
+const GF_MULT MASK = GF_MULT(0xFFFFFFFFFFFFFFFF);
+
+const GF OMEGA[33] = {
+	GF(1ull),						// for a domain of 2^0
+	GF(18446744069414584320ull),	// for a domain of 2^1
+	GF(281474976710656ull),			// for a domain of 2^2
+	GF(18446744069397807105ull),	// for a domain of 2^3
+	GF(17293822564807737345ull),	// for a domain of 2^4
+	GF(70368744161280ull),			// for a domain of 2^5
+	GF(549755813888ull),			// for a domain of 2^6
+	GF(17870292113338400769ull),	// for a domain of 2^7
+	GF(13797081185216407910ull),	// for a domain of 2^8
+	GF(1803076106186727246ull),		// for a domain of 2^9
+	GF(11353340290879379826ull),	// for a domain of 2^10
+	GF(455906449640507599ull),		// for a domain of 2^11
+	GF(17492915097719143606ull),	// for a domain of 2^12
+	GF(1532612707718625687ull),		// for a domain of 2^13
+	GF(16207902636198568418ull),	// for a domain of 2^14
+	GF(17776499369601055404ull),	// for a domain of 2^15
+	GF(6115771955107415310ull),		// for a domain of 2^16
+	GF(12380578893860276750ull),	// for a domain of 2^17
+	GF(9306717745644682924ull),		// for a domain of 2^18
+	GF(18146160046829613826ull),	// for a domain of 2^19
+	GF(3511170319078647661ull),		// for a domain of 2^20
+	GF(17654865857378133588ull),	// for a domain of 2^21
+	GF(5416168637041100469ull),		// for a domain of 2^22
+	GF(16905767614792059275ull),	// for a domain of 2^23
+	GF(9713644485405565297ull),		// for a domain of 2^24
+	GF(5456943929260765144ull),		// for a domain of 2^25
+	GF(17096174751763063430ull),	// for a domain of 2^26
+	GF(1213594585890690845ull), 	// for a domain of 2^27
+	GF(6414415596519834757ull), 	// for a domain of 2^28
+	GF(16116352524544190054ull), 	// for a domain of 2^29
+	GF(9123114210336311365ull), 	// for a domain of 2^30
+	GF(4614640910117430873ull), 	// for a domain of 2^31
+	GF(1753635133440165772ull) 		// for a domain of 2^32
+};
+
+GF add(GF left, GF right);
+GF sub(GF left, GF right);
+GF negate(GF x);
+GF mult(GF left, GF right);
+GF to_canonical(GF x);
+
+#endif

--- a/ntt/reference_code/arithmetic_test.cpp
+++ b/ntt/reference_code/arithmetic_test.cpp
@@ -1,0 +1,111 @@
+/*
+ * Copyright (C) 2022 DZK
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "arithmetic.hpp"
+#include <vector>
+
+using namespace std;
+
+vector<GF> get_test_vector() {
+	vector<GF> test_vector;
+
+	for (int i = 0; i < 10; i++) {
+		// add the test cases 0..10
+		test_vector.push_back(GF(i));
+
+		// add the (1 << 31) - 10..(1 << 31) + 10
+		test_vector.push_back(GF(1 << 31 - 10 + i));
+		test_vector.push_back(GF(1 << 31 + i));
+
+		// add the (1 << 32) - 10..(1 << 32) + 10
+		test_vector.push_back(GF(1 << 32 - 10 + i));
+		test_vector.push_back(GF(1 << 32 + i));
+
+		// add the (1 << 63) - 10..(1 << 63) + 10
+		test_vector.push_back(GF(1 << 63 - 10 + i));
+		test_vector.push_back(GF(1 << 63 + i));
+
+		// add the MODULUS - 10..MODULUS
+		test_vector.push_back(MODULUS - GF(10 - i));
+	}
+
+	return test_vector;
+}
+
+int arithmetic_test() {
+	cout << "Running arithmetic test." << endl;
+
+	vector<GF> test_vector = get_test_vector();
+	for(int i = 0; i < test_vector.size(); i++) {
+		for(int j = 0; j < test_vector.size(); j++) {
+			GF left = test_vector.at(i);
+			GF right = test_vector.at(j);
+
+			while(left >= MODULUS) {
+				left -= MODULUS;
+			}
+			while(right >= MODULUS) {
+				right -= MODULUS;
+			}
+
+			// check if addition is done correctly
+			GF actual = to_canonical(add(left, right));
+			GF expected = left + right;
+			while(expected >= MODULUS) {
+				expected -= MODULUS;
+			}
+
+			if(actual != expected){
+				cout << "Error: Compute " + left.to_string(10) + " + " + right.to_string(10) + ": expected " + expected.to_string(10) + " actual " + actual.to_string(10) << endl;
+				return 1;
+			}
+
+			// check if subtraction is done correctly
+			actual = to_canonical(sub(left, right));
+			if(left >= right) {
+				expected = left - right;
+			} else {
+				expected = MODULUS - (right - left);
+			}
+
+			if(actual != expected){
+				cout << "Error: Compute " + left.to_string(10) + " - " + right.to_string(10) + ": expected " + expected.to_string(10) + " actual " + actual.to_string(10) << endl;
+				return 1;
+			}
+
+			// check if multiplication is done correctly
+			actual = to_canonical(mult(left, right));
+			{
+				ap_ulong left_u64 = left.to_uint64();
+				ap_ulong right_u64 = right.to_uint64();
+				ap_ulong modulus_u64 = MODULUS.to_uint64();
+
+				GF_MULT left_u128 = GF_MULT(left_u64);
+				GF_MULT right_u128 = GF_MULT(right_u64);
+				GF_MULT modulus_u128 = GF_MULT(modulus_u64);
+
+				GF_MULT res_u128 = (left_u128 * right_u128) % modulus_u128;
+				expected = GF(res_u128.to_uint64());
+			}
+			if(actual != expected){
+				cout << "Error: Compute " + left.to_string(10) + " * " + right.to_string(10) + ": expected " + expected.to_string(10) + " actual " + actual.to_string(10) << endl;
+				return 1;
+			}
+		}
+	}
+
+	return 0;
+}

--- a/ntt/reference_code/main.cpp
+++ b/ntt/reference_code/main.cpp
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2022 DZK
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <iostream>
+
+int arithmetic_test();
+int ntt_test();
+
+using namespace std;
+
+int main(){
+	int res = arithmetic_test();
+	if(res != 0){
+		return res;
+	}
+
+	res = ntt_test();
+	if(res != 0){
+		return res;
+	}
+
+	cout << "All test passed." << endl;
+	return 0;
+}

--- a/ntt/reference_code/ntt.cpp
+++ b/ntt/reference_code/ntt.cpp
@@ -1,0 +1,122 @@
+/*
+ * Copyright (C) 2022 DZK
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "ntt.hpp"
+
+void NTT_2_3_in_place(GF (&in)[8]) {
+	const int n = 8;
+	const int logn = 3;
+
+	typedef ap_uint<logn> INDEX;
+
+	GF tmp;
+	for (INDEX k = INDEX(0);;) {
+		INDEX rk = k;
+		rk.reverse();
+		if (k < rk) {
+			tmp = in[rk];
+			in[rk] = in[k];
+			in[k] = tmp;
+		}
+
+		k++;
+		if (k.iszero()) { // overflow
+			break;
+		}
+	}
+
+	int m = 1;
+	for (int i = 1; i <= logn; i++) {
+		// w_m is 2^i-th root of unity
+		GF w_m = OMEGA[i];
+
+		int k = 0;
+		while (k < n) {
+			// w = w_m^j at the start of every loop iteration
+			GF w = ONE;
+
+			for (int j = 0; j < m; j++) {
+				GF t = in[k + j + m];
+				t = mult(t, w);
+
+				GF tmp = in[k + j];
+				tmp = sub(tmp, t);
+
+				in[k + j + m] = tmp;
+				in[k + j] = add(in[k + j], t);
+
+				w = mult(w, w_m);
+			}
+
+			k += 2 * m;
+		}
+
+		m *= 2;
+	}
+}
+
+void NTT_2_12_in_place(GF (&in)[4096]) {
+	const int n = 4096;
+	const int logn = 12;
+
+	typedef ap_uint<logn> INDEX;
+
+	GF tmp;
+	for (INDEX k = INDEX(0);;) {
+		INDEX rk = k;
+		rk.reverse();
+		if (k < rk) {
+			tmp = in[rk];
+			in[rk] = in[k];
+			in[k] = tmp;
+		}
+
+		k++;
+		if (k.iszero()) { // overflow
+			break;
+		}
+	}
+
+	int m = 1;
+	for (int i = 1; i <= logn; i++) {
+		// w_m is 2^i-th root of unity
+		GF w_m = OMEGA[i];
+
+		int k = 0;
+		while (k < n) {
+			// w = w_m^j at the start of every loop iteration
+			GF w = ONE;
+
+			for (int j = 0; j < m; j++) {
+				GF t = in[k + j + m];
+				t = mult(t, w);
+
+				GF tmp = in[k + j];
+				tmp = sub(tmp, t);
+
+				in[k + j + m] = tmp;
+				in[k + j] = add(in[k + j], t);
+
+				w = mult(w, w_m);
+			}
+
+			k += 2 * m;
+		}
+
+		m *= 2;
+	}
+}
+

--- a/ntt/reference_code/ntt.hpp
+++ b/ntt/reference_code/ntt.hpp
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2022 DZK
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef _NTT_FUNC_H_
+#define _NTT_FUNC_H_
+
+#include "arithmetic.hpp"
+
+void NTT_2_3_in_place(GF (&in)[8]);
+void NTT_2_12_in_place(GF (&in)[4096]);
+
+#endif

--- a/ntt/reference_code/ntt_test.cpp
+++ b/ntt/reference_code/ntt_test.cpp
@@ -1,0 +1,122 @@
+/*
+ * Copyright (C) 2022 DZK
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "ntt.hpp"
+#include <iostream>
+
+using namespace std;
+
+int test_2_3_linear() {
+	GF in[8];
+	for (int i = 0; i < 8; i++) {
+		in[i] = ZERO;
+	}
+
+	in[0] = ONE;
+	in[1] = TWO;
+
+	NTT_2_3_in_place(in);
+
+	GF expected_out[8] = { GF(0x0000000000000003), GF(0xfffffffefe000002), GF(
+			0x0002000000000001), GF(0xfffffdff00000202), GF(0xffffffff00000000),
+			GF(0x0000000002000001), GF(0xfffdffff00000002), GF(
+					0x000001fffffffe01) };
+
+	for (int i = 0; i < 8; i++) {
+		if (in[i] != expected_out[i]) {
+			cout << "Error: NTT result [" << i << "] should be "
+					<< expected_out[i].to_string(10) << ", but the output is "
+					<< in[i].to_string(10) << endl;
+			return 1;
+		}
+	}
+
+	return 0;
+}
+
+int test_2_12_linear() {
+	GF in[4096];
+	for (int i = 0; i < 4096; i++) {
+		in[i] = ZERO;
+	}
+
+	in[0] = ONE;
+	in[1] = TWO;
+
+	NTT_2_12_in_place(in);
+
+	// we only test the first eight elements
+	GF expected_out[8] = { GF(0x0000000000000003), GF(0xe586a3342b3bf96c), GF(
+			0x0ca769003b43919f), GF(0x28b1a9691a680e3c), GF(0x3b1e55b017fdb2e4),
+			GF(0x309d8a339a00ae6a), GF(0xdc13ebf6fd47c483), GF(
+					0xc12decfb84bb920e) };
+
+	for (int i = 0; i < 8; i++) {
+		if (in[i] != expected_out[i]) {
+			cout << "Error: NTT result [" << i << "] should be "
+					<< expected_out[i].to_string(10) << ", but the output is "
+					<< in[i].to_string(10) << endl;
+			return 1;
+		}
+	}
+
+	return 0;
+}
+
+int test_2_3_fully_random() {
+	GF in[8] = { GF(0xcef967e3e1d0860e), GF(0x44be7570bcd4f9df), GF(
+			0xf4848ed283e858f2), GF(0xa3a3a47eeb6f76f6), GF(0xa12d1d0b69c4108b),
+			GF(0xeb285d19459ef6c3), GF(0x10d812558ad9c103), GF(
+					0xd19d3e319d1b6b4a) };
+	NTT_2_3_in_place(in);
+
+	GF expected_out[8] = { GF(0x1aaadb56e555836b), GF(0x975bcb9d395a282f), GF(
+			0x69055db04cf94815), GF(0x963cdab11477cc1c), GF(0xd05b70dbcf57ddad),
+			GF(0xed14bc2fbdc30962), GF(0x6c8e69de2cabb133), GF(
+					0x9c83c8e1d49cd861) };
+
+	for (int i = 0; i < 8; i++) {
+		if (in[i] != expected_out[i]) {
+			cout << "Error: NTT result [" << i << "] should be "
+					<< expected_out[i].to_string(10) << ", but the output is "
+					<< in[i].to_string(10) << endl;
+			return 1;
+		}
+	}
+
+	return 0;
+}
+
+int ntt_test() {
+	cout << "Running NTT test." << endl;
+
+	int res = test_2_3_linear();
+	if (res != 0) {
+		return res;
+	}
+
+	res = test_2_12_linear();
+	if (res != 0) {
+		return res;
+	}
+
+	res = test_2_3_fully_random();
+	if (res != 0) {
+		return res;
+	}
+
+	return 0;
+}


### PR DESCRIPTION
Add the C++ HLS implementation files for the NTT competition.

I have not included any tcl or vivado solution nonsense - I doubt we'll need it.

The package included a bunch of testfiles upto 300MB in size which we will need to deal with seperately.