### PR TITLE
Optimize barret reduction resource usage.

### DIFF
--- a/shared/src/barrett_reduction.ml
+++ b/shared/src/barrett_reduction.ml
@@ -1,12 +1,12 @@
 (* Calculates [a mod p] using barret reduction, where [p] is a compile-time
    known constant.
-  
+
    Based on implementation in 
    https://github.com/ZcashFoundation/zcash-fpga/blob/c4c0ad918898084c73528ca231d025e36740d40c/ip_cores/util/src/rtl/barret_mod_pipe.sv
-  
+
    Computes the following in separate pipeline stages, where
    k = Int.ceillog(p)
-   
+
    {[
      let reduce ~p ~k a =
        let q = (a * m) >> k in
@@ -16,7 +16,7 @@
          (a_minus_qp - p)
          a_minus_qp
    ]}
- *)
+*)
 
 open Base
 open Hardcaml
@@ -26,11 +26,13 @@ open Reg_with_enable
 module Config = struct
   type t =
     { multiplier_config : Karatsuba_ofman_mult.Config.t
+    ; half_multiplier_config : Half_width_multiplier.Config.t
     ; subtracter_stages : int
     }
 
   let latency (config : t) =
-    (2 * Karatsuba_ofman_mult.Config.latency config.multiplier_config)
+    (1 * Karatsuba_ofman_mult.Config.latency config.multiplier_config)
+    + (1 * Half_width_multiplier.Config.latency config.half_multiplier_config)
     + (2 * Modulo_subtractor_pipe.latency ~stages:config.subtracter_stages)
   ;;
 end
@@ -46,12 +48,12 @@ end
 module Stage1 = struct
   type 'a t =
     { q : 'a
-    ; a : 'a
+    ; a' : 'a
     ; valid : 'a
     }
   [@@deriving sexp_of, hardcaml]
 
-  let create ~scope ~clock ~enable ~m ~k ~(config : Config.t) { Stage0.a; valid } =
+  let create ~scope ~clock ~enable ~m ~k ~p ~(config : Config.t) { Stage0.a; valid } =
     let logm = Z.log2up m in
     let wa = Signal.width a in
     let multiplier_config = config.multiplier_config in
@@ -71,7 +73,7 @@ module Stage1 = struct
           (`Constant m)
         |> Fn.flip drop_bottom k
         |> Fn.flip sel_bottom (wa + logm - k)
-    ; a = pipeline ~enable ~n:latency spec a
+    ; a' = pipeline ~enable ~n:latency spec (sel_bottom a (1 + Z.log2up p))
     ; valid = pipeline ~enable ~n:latency spec valid
     }
   ;;
@@ -80,26 +82,29 @@ end
 module Stage2 = struct
   type 'a t =
     { qp : 'a
-    ; a : 'a
+    ; a' : 'a
     ; valid : 'a
     }
   [@@deriving sexp_of, hardcaml]
 
-  let create ~clock ~scope ~enable ~p ~(config : Config.t) { Stage1.q; a; valid } =
-    let multiplier_config = config.multiplier_config in
-    let latency = Karatsuba_ofman_mult.Config.latency multiplier_config in
+  let create ~clock ~scope ~enable ~p ~(config : Config.t) { Stage1.q; a'; valid } =
+    let a_minus_qp_width =
+      (* [a - qp] possible range of values ios [0, 2p) *)
+      1 + Z.log2up p
+    in
+    let latency = Half_width_multiplier.Config.latency config.half_multiplier_config in
     let spec = Reg_spec.create ~clock () in
     assert (width q >= Z.log2up p);
+    ignore (a_minus_qp_width : int);
     { qp =
-        Karatsuba_ofman_mult.hierarchical
-          ~config:multiplier_config
+        Half_width_multiplier.hierarchical
           ~scope
           ~clock
           ~enable
-          q
-          (`Constant p)
-        |> Fn.flip sel_bottom (width a)
-    ; a = pipeline ~enable ~n:latency spec a
+          ~config:config.half_multiplier_config
+          (Multiply_by_constant
+             (sel_bottom q a_minus_qp_width, Bits.of_z ~width:a_minus_qp_width p))
+    ; a' = pipeline ~enable ~n:latency spec a'
     ; valid = pipeline ~enable ~n:latency spec valid
     }
   ;;
@@ -112,7 +117,7 @@ module Stage3 = struct
     }
   [@@deriving sexp_of, hardcaml]
 
-  let create ~clock ~enable ~p ~(config : Config.t) { Stage2.qp; a; valid } =
+  let create ~scope ~clock ~enable ~p ~(config : Config.t) { Stage2.qp; a'; valid } =
     let spec = Reg_spec.create ~clock () in
     let stages = config.subtracter_stages in
     let latency = Modulo_subtractor_pipe.latency ~stages in
@@ -120,9 +125,17 @@ module Stage3 = struct
       (* [a - qp] possible range of values ios [0, 2p) *)
       1 + Z.log2up p
     in
+    assert (width a' = a_minus_qp_width);
+    assert (width qp = a_minus_qp_width);
     { a_minus_qp =
-        Modulo_subtractor_pipe.create ~clock ~enable ~stages ~p a qp
-        |> Fn.flip sel_bottom a_minus_qp_width
+        Adder_subtractor_pipe.hierarchical
+          ~stages
+          ~scope
+          ~enable
+          ~clock
+          { lhs = a'; rhs_list = [ { op = `Sub; term = qp } ] }
+        |> List.hd_exn
+        |> Adder_subtractor_pipe.Single_op_output.result
     ; valid = pipeline ~enable ~n:latency spec valid
     }
   ;;
@@ -185,11 +198,11 @@ struct
     let { Stage4.a_mod_p; valid } =
       let ( -- ) = Scope.naming scope in
       { Stage0.a; valid }
-      |> Stage1.create ~scope ~clock ~enable ~m ~k ~config
+      |> Stage1.create ~scope ~clock ~enable ~m ~k ~p ~config
       |> Stage1.map2 Stage1.port_names ~f:(fun n s -> s -- ("stage1$" ^ n))
       |> Stage2.create ~scope ~clock ~enable ~p ~config
       |> Stage2.map2 Stage2.port_names ~f:(fun n s -> s -- ("stage2$" ^ n))
-      |> Stage3.create ~clock ~enable ~p ~config
+      |> Stage3.create ~scope ~clock ~enable ~p ~config
       |> Stage3.map2 Stage3.port_names ~f:(fun n s -> s -- ("stage3$" ^ n))
       |> Stage4.create ~clock ~enable ~p ~config
       |> Stage4.map2 Stage4.port_names ~f:(fun n s -> s -- ("stage4$" ^ n))

--- a/shared/src/barrett_reduction.mli
+++ b/shared/src/barrett_reduction.mli
@@ -3,6 +3,7 @@ open Hardcaml
 module Config : sig
   type t =
     { multiplier_config : Karatsuba_ofman_mult.Config.t
+    ; half_multiplier_config : Half_width_multiplier.Config.t
     ; subtracter_stages : int
     }
 

--- a/shared/src/config_presets.ml
+++ b/shared/src/config_presets.ml
@@ -23,6 +23,10 @@ module For_bls12_377 = struct
         Karatsuba_ofman_mult.Config.generate
           ~ground_multiplier:(Verilog_multiply { latency = 3 })
           [ Radix_3; Radix_3 ]
+    ; half_multiplier_config =
+        { level_radices = [ Radix_3; Radix_3; Radix_2 ]
+        ; ground_multiplier = Hybrid_dsp_and_luts { latency = 3 }
+        }
     ; subtracter_stages = 3
     }
   ;;

--- a/shared/test/test_ec_fpn_dbl_with_barrett_reduction.ml
+++ b/shared/test/test_ec_fpn_dbl_with_barrett_reduction.ml
@@ -7,7 +7,7 @@ let latency = Ec_fpn_dbl.latency config
 
 let%expect_test "latency" =
   Stdio.printf "latency = %d\n" latency;
-  [%expect {| latency = 107 |}]
+  [%expect {| latency = 110 |}]
 ;;
 
 let%expect_test "Test on random test cases" =


### PR DESCRIPTION
- Replace one of the multiplication with a half multiplication, as only
  the bottom 378 bit is required.
- Replace a modulo sub circuit with a vanilla pipelined sub circuit