### PR TITLE
Add a layer of configurable pipelining to twisted edwards adder output.

### DIFF
--- a/twisted_edwards/src/mixed_add.mli
+++ b/twisted_edwards/src/mixed_add.mli
@@ -16,6 +16,7 @@ module Config : sig
     ; p : Z.t
     ; a : Z.t
     ; d : Z.t
+    ; output_pipeline_stages : int
     }
 
   module For_bls12_377 : sig


### PR DESCRIPTION
The pipeline registers are meant to aid with routing, so they contain a
don't_touch annotation (when pipelining is zero). I confirmed that there
is a FDRE by manually inspecting the dcp.