### PR TITLE
Remove extra pipeline depth to the controller, fix top level test to un over the full MSM design

### DIFF
--- a/zprize/msm_pippenger/hardcaml/src/top.ml
+++ b/zprize/msm_pippenger/hardcaml/src/top.ml
@@ -51,10 +51,9 @@ module Make (Config : Config.S) = struct
     let num_windows = num_windows
     let affine_point_bits = input_point_bits
 
-    (* TODO: This pipeline depth is way larger than it should need to be, try find out why... *)
     let pipeline_depth =
       Int.round_up
-        (adder_latency + ram_lookup_latency + ram_read_latency + ram_write_latency + 100)
+        (adder_latency + ram_lookup_latency + ram_read_latency + ram_write_latency + 2)
         ~to_multiple_of:2
       / 2
     ;;

--- a/zprize/msm_pippenger/host/host.cpp
+++ b/zprize/msm_pippenger/host/host.cpp
@@ -23,7 +23,7 @@
 
 #define BITS_PER_INPUT_POINT 377*3
 #define BITS_PER_OUTPUT_POINT 377*4
-#define SCALAR_BITS 12
+#define SCALAR_BITS 253
 #define DDR_BITS 512
 
 // We round up our points to the nearest multiple of the AXI stream / DDR

--- a/zprize/msm_pippenger/test/run_hw_emu.sh
+++ b/zprize/msm_pippenger/test/run_hw_emu.sh
@@ -14,6 +14,6 @@ cp ../host/host.exe ./
 sed -e "s#CURRENT_DIRECTORY#$PWD#g" xrt.template.ini >xrt.ini
 
 # Run this to get the input and output points file. Make sure the -window and -scalar settings match the FPGA build
-dune exec -- ../hardcaml/bin/tools.exe test-vectors -input input.points -output output.points -num 8
+dune exec -- ../hardcaml/bin/tools.exe test-vectors -input input.points -output output.points -num 1024
 
 XCL_EMULATION_MODE=hw_emu ./host.exe ../fpga/build/build_dir.hw_emu.xilinx_aws-vu9p-f1_shell-v04261818_201920_3/msm_pippenger.xclbin input.points output.points


### PR DESCRIPTION
Remove extra pipeline depth to the controller, fix top level test to un over the full MSM design