### PR TITLE
Support mixed multiplier that uses just DSPs or just LUTs or hybrid

### DIFF
--- a/libs/field_ops/src/ground_multiplier.mli
+++ b/libs/field_ops/src/ground_multiplier.mli
@@ -7,6 +7,21 @@ module Config : sig
         { latency : int
         ; lut_only_hamming_weight_threshold : int
         }
+    | Mixed of
+        { latency : int
+        ; lut_only_hamming_weight_threshold : int option
+            (** Implements the ground multiplier with luts if the hamming
+             * weight of [argb] is less than
+             * lut_only_hamming_weight_threshold]. Skips this optimization if
+             * it's None.
+            *)
+        ; hybrid_hamming_weight_threshold : int option
+            (** Implements the ground multiplier with a hybrid dsp+lut
+             * multiplier if the hamming weight of [argb] is less than
+             * lut_only_hamming_weight_threshold]. Skips this optimization
+             * if it's None.
+            *)
+        }
     | Specialized_43_bit_multiply
   [@@deriving sexp_of]
 


### PR DESCRIPTION
Add support for DSP-only / LUT-only ground multipliers.

This is not used directly anywhere yet.